### PR TITLE
droid-src: Fix size mismatch when using codecs from 64-bit userspace.

### DIFF
--- a/patches/frameworks/av/0001-hybris-Fix-32-bit-vs-64-bit-size-mismatch-in-codecs.patch
+++ b/patches/frameworks/av/0001-hybris-Fix-32-bit-vs-64-bit-size-mismatch-in-codecs.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Lehtimaki <matti.lehtimaki@jolla.com>
+Date: Thu, 5 Nov 2020 20:46:35 +0200
+Subject: [PATCH] (hybris) Fix 32-bit vs 64-bit size mismatch in codecs.
+
+Change-Id: I50e928113f90eea9d85f79f183c4b74113ab73bf
+---
+ media/libstagefright/ACodec.cpp | 27 +++++++++++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/media/libstagefright/ACodec.cpp b/media/libstagefright/ACodec.cpp
+index 44f246d849..fd4b3872e4 100644
+--- a/media/libstagefright/ACodec.cpp
++++ b/media/libstagefright/ACodec.cpp
+@@ -877,10 +877,11 @@ status_t ACodec::allocateBuffersOnPort(OMX_U32 portIndex) {
+             // Always allocate VideoNativeMetadata if using ANWBuffer.
+             // OMX might use gralloc source internally, but we don't share
+             // metadata buffer with OMX, OMX has its own headers.
++            // hybris: allocate buffer that can fit 64-bit native handle if compiled in 64-bit mode
+             if (mode == IOMX::kPortModeDynamicANWBuffer) {
+-                bufSize = sizeof(VideoNativeMetadata);
++                bufSize = sizeof(VideoNativeMetadata_ptrSized);
+             } else if (mode == IOMX::kPortModeDynamicNativeHandle) {
+-                bufSize = sizeof(VideoNativeHandleMetadata);
++                bufSize = sizeof(VideoNativeHandleMetadata_ptrSized);
+             }
+ 
+             size_t conversionBufferSize = 0;
+@@ -6146,6 +6147,28 @@ void ACodec::BaseState::onInputBufferFilled(const sp<AMessage> &msg) {
+                             bufferID, graphicBuffer, flags, timeUs, info->mFenceFd);
+                     }
+                     break;
++#else
++                // hybris: convert data from 64-bit camera process to 32-bit OMX if needed
++                case IOMX::kPortModeDynamicNativeHandle:
++                    if (info->mCodecData->size() >= sizeof(VideoNativeHandleMetadata_ptrSized)
++                            && sizeof(VideoNativeHandleMetadata) != sizeof(VideoNativeHandleMetadata_ptrSized)) {
++                        VideoNativeHandleMetadata_ptrSized *vnhmd =
++                            (VideoNativeHandleMetadata_ptrSized*)info->mCodecData->base();
++                        sp<NativeHandle> handle = NativeHandle::create(
++                                (native_handle *)vnhmd->pHandle, false /* ownsHandle */);
++                        err2 = mCodec->mOMXNode->emptyBuffer(
++                            bufferID, handle, flags, timeUs, info->mFenceFd);
++                    }
++                    break;
++                case IOMX::kPortModeDynamicANWBuffer:
++                    if (info->mCodecData->size() >= sizeof(VideoNativeMetadata_ptrSized)
++                            && sizeof(VideoNativeMetadata) != sizeof(VideoNativeMetadata_ptrSized)) {
++                        VideoNativeMetadata_ptrSized *vnmd = (VideoNativeMetadata_ptrSized*)info->mCodecData->base();
++                        sp<GraphicBuffer> graphicBuffer = GraphicBuffer::from(vnmd->pBuffer);
++                        err2 = mCodec->mOMXNode->emptyBuffer(
++                            bufferID, graphicBuffer, flags, timeUs, info->mFenceFd);
++                    }
++                    break;
+ #endif
+                 default:
+                     ALOGW("Can't marshall %s data in %zu sized buffers in %zu-bit mode",
+-- 
+2.26.2
+

--- a/patches/frameworks/native/0001-hybris-Add-native-buffer-compat-define.patch
+++ b/patches/frameworks/native/0001-hybris-Add-native-buffer-compat-define.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matti Lehtimaki <matti.lehtimaki@jolla.com>
+Date: Thu, 5 Nov 2020 20:50:40 +0200
+Subject: [PATCH] (hybris) Add native buffer compat define.
+
+Change-Id: Iaa50a8270fc822fa3aacec07a5dcdfc467752afe
+---
+ headers/media_plugin/media/hardware/HardwareAPI.h | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/headers/media_plugin/media/hardware/HardwareAPI.h b/headers/media_plugin/media/hardware/HardwareAPI.h
+index ae0220a5e..05e9559a5 100644
+--- a/headers/media_plugin/media/hardware/HardwareAPI.h
++++ b/headers/media_plugin/media/hardware/HardwareAPI.h
+@@ -150,6 +150,12 @@ struct VideoNativeMetadata {
+     int nFenceFd;                           // -1 if unused
+ };
+ 
++struct VideoNativeMetadata_ptrSized {
++    MetadataBufferType eType;               // must be kMetadataBufferTypeANWBuffer
++    struct ANativeWindowBuffer* pBuffer;
++    int nFenceFd;                           // -1 if unused
++};
++
+ // Meta data buffer layout for passing a native_handle to codec
+ struct VideoNativeHandleMetadata {
+     MetadataBufferType eType;               // must be kMetadataBufferTypeNativeHandleSource
+@@ -161,6 +167,14 @@ struct VideoNativeHandleMetadata {
+ #endif
+ };
+ 
++// Meta data buffer layout for passing a native_handle to codec
++// mer-hybris: 64-bit version used in conversion code for 32-bit OMX
++struct VideoNativeHandleMetadata_ptrSized {
++    MetadataBufferType eType;               // must be kMetadataBufferTypeNativeHandleSource
++
++    native_handle_t *pHandle;
++};
++
+ // A pointer to this struct is passed to OMX_SetParameter() when the extension
+ // index "OMX.google.android.index.prepareForAdaptivePlayback" is given.
+ //
+-- 
+2.26.2
+


### PR DESCRIPTION
[droid-src] Fix size mismatch when using codecs from 64-bit userspace. JB#52325