### PR TITLE
(hybris) device: sony: lena: Disable sensors of tele and uwide lenses for now

### DIFF
--- a/patches/device/sony/lena/0002-hybris-camxoverridesettings-Disable-sensors-of-tele-.patch
+++ b/patches/device/sony/lena/0002-hybris-camxoverridesettings-Disable-sensors-of-tele-.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Bidar?= <bjorn.bidar@jolla.com>
+Date: Mon, 28 Mar 2022 06:39:33 +0300
+Subject: [PATCH] (hybris) camxoverridesettings: Disable sensors of tele and
+ uwide lenses for now
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Support for multiple rear camera lenses sadly creates issues when
+switching between cameras in Camera1 API mode. Disable it to
+avoid those. After we have Camera2 API support we can revert this.
+
+This will disable sensors of tele and uwide lenses.
+
+Re:
+https://github.com/sonyxperiadev/bug_tracker/issues/732
+
+[hybris] camxoverridesettings: Disable sensors of tele and uwide lenses for now. JB#56689
+
+Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>
+---
+ rootdir/vendor/etc/camera/camxoverridesettings.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/rootdir/vendor/etc/camera/camxoverridesettings.txt b/rootdir/vendor/etc/camera/camxoverridesettings.txt
+index 441981b511bd9c6c4da5f1764d286357c6b7814f..4a94a5a1bc2a177299ec64d6680408c64b06340a 100644
+--- a/rootdir/vendor/etc/camera/camxoverridesettings.txt
++++ b/rootdir/vendor/etc/camera/camxoverridesettings.txt
+@@ -13,7 +13,10 @@ numMetadataResults=1
+ maxNonHfrFps=120
+ 
+ enableDualIFE=TRUE
+-multiCameraEnable=TRUE
++# Disable multiple rear camera lenses support to avoid issues when switching between cameras
++# when using Camera1 API. We can revert this when this when we have Camera2 API support.
++# Re: https://github.com/sonyxperiadev/bug_tracker/issues/732
++multiCameraEnable=FALSE
+ multiCameraHWSyncMask=0x7
+ dualBHistSupport=TRUE
+ overrideEnableMFNR=1


### PR DESCRIPTION
Support for multiple rear camera lenses sadly creates issues when
switching between cameras in Camera1 API mode. Disable it to
avoid those. After we have Camera2 API support we can revert this.

This will disable sensors of tele and uwide lenses.

Re:
https://github.com/sonyxperiadev/bug_tracker/issues/732