### PR TITLE
(hybris) init: Enable low memory killer for Edo (Xperia 1/5 II)

### DIFF
--- a/patches/device/sony/edo/0001-hybris-init-Enable-low-memory-killer.patch
+++ b/patches/device/sony/edo/0001-hybris-init-Enable-low-memory-killer.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Bidar?= <bjorn.bidar@jolla.com>
+Date: Sun, 21 Apr 2024 13:53:07 +0300
+Subject: [PATCH] (hybris) init: Enable low memory killer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+minfree values have been set to be 50% higher than in Xperia 10 III.
+
+This is to allow extra memory buffer for any apps that might need to
+allocate a bigger chunk every so often.
+
+Increase values by 50% from Xperia 10 III as the Xperia 1/5 II has
+the same memory increase from Xperia 10 II to 10 III.
+
+[hybris] init: Enable low memory killer. JB#57685
+
+Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>
+---
+ rootdir/vendor/etc/init/init.edo.rc | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/rootdir/vendor/etc/init/init.edo.rc b/rootdir/vendor/etc/init/init.edo.rc
+index 74f540e741333057527a09833baa24d8178e798a..5b0c32227469750e0507f7e1e5ffb55a874d5900 100644
+--- a/rootdir/vendor/etc/init/init.edo.rc
++++ b/rootdir/vendor/etc/init/init.edo.rc
+@@ -69,3 +69,10 @@ on property:sys.boot_completed=1
+     write /sys/block/sdc/queue/iostats 1
+     write /sys/block/dm-0/queue/read_ahead_kb 512
+     write /sys/block/dm-1/queue/read_ahead_kb 512
++
++# LMK tuning
++    write /sys/module/lowmemorykiller/parameters/enable_lmk 1
++    write /sys/module/lowmemorykiller/parameters/minfree "334320, 380400, 426480, 472560, 712980"
++    write /sys/module/lowmemorykiller/parameters/adj "0,58,147,529,1000"
++    write /sys/module/lowmemorykiller/parameters/vmpressure_file_min 105984
++    write /sys/module/lowmemorykiller/parameters/oom_reaper 1


### PR DESCRIPTION
minfree values have been set to be 50% higher than in Xperia 10 III.

This is to allow extra memory buffer for any apps that might need to
allocate a bigger chunk every so often.

Increase values by 50% from Xperia 10 III as the Xperia 1/5 II has
the same memory increase from Xperia 10 II to 10 III.